### PR TITLE
Fixed mismatched variable.

### DIFF
--- a/netbanx.php
+++ b/netbanx.php
@@ -81,7 +81,7 @@ function netbanx_civicrm_buildForm($formName, &$form) {
     $f($form);
   }
 
-  $payment_input_forms = array(
+  $payment_forms = array(
     'CRM_Contribute_Form_Contribution_Main',
     'CRM_Event_Form_Registration_Register',
   );


### PR DESCRIPTION
This should get rid of the following warning:

```
Warning : in_array() expects parameter 2 to be array, null given dans netbanx_civicrm_buildForm() (ligne 89 dans /srv/chroot/bpq-sftponly/cbpq.qc.ca/files/civi-extensions/coop.symbiotic.netbanx/netbanx.php).
```
